### PR TITLE
Fail job if the tests fail

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -157,3 +157,5 @@ jobs:
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'
+      - name: Fail job if spec failure
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi


### PR DESCRIPTION
In order for the overall Github Action to reflect test failures, it needs to fail the test step if the tests fail.